### PR TITLE
fix: validation code fantoir

### DIFF
--- a/src/frformat/geo/code_fantoir.py
+++ b/src/frformat/geo/code_fantoir.py
@@ -10,11 +10,11 @@ description = "Vérifie les codes fantoirs valides"
 class CodeFantoir(CustomFormat):
     @classmethod
     def name(cls) -> str:
-        return "SIREN"
+        return name
 
     @classmethod
     def description(cls) -> str:
-        return "Check french SIREN number validity, but does not check if SIREN number exists."
+        return description
 
     @classmethod
     def is_valid(cls, value: str) -> bool:

--- a/src/frformat/geo/code_fantoir.py
+++ b/src/frformat/geo/code_fantoir.py
@@ -1,7 +1,28 @@
-from frformat import enum_format
-from frformat.geo.code_fantoir_set import CODE_FANTOIR_SET
+import re
+
+from frformat import CustomFormat
+from frformat.geo.code_fantoir_set import PARTIAL_CODE_FANTOIR_SET
 
 name = "Code fantoir"
 description = "Vérifie les codes fantoirs valides"
 
-CodeFantoir = enum_format.new(name, description, CODE_FANTOIR_SET)
+
+class CodeFantoir(CustomFormat):
+    @classmethod
+    def name(cls) -> str:
+        return "SIREN"
+
+    @classmethod
+    def description(cls) -> str:
+        return "Check french SIREN number validity, but does not check if SIREN number exists."
+
+    @classmethod
+    def is_valid(cls, value: str) -> bool:
+        if not bool(re.match(r"^[0-9A-Z]{2}[0-9]{2}[ABCDEFGHJKLMNPRSTUVWXYZ]$", value)):
+            return False
+
+        return value[:4] in PARTIAL_CODE_FANTOIR_SET
+
+    @classmethod
+    def _format(cls, value: str) -> str:
+        return f"{value[0:3]} {value[3:6]} {value[6:]}"

--- a/src/frformat/geo/code_fantoir_set.py
+++ b/src/frformat/geo/code_fantoir_set.py
@@ -1,4 +1,4 @@
-CODE_FANTOIR_SET = {
+PARTIAL_CODE_FANTOIR_SET = {
     "0000",
     "0001",
     "0002",

--- a/src/tests/test_geo_fr.py
+++ b/src/tests/test_geo_fr.py
@@ -12,17 +12,20 @@ from frformat import (
     Pays,
     Region,
 )
-from tests.testing import strict_lenient_test_helper_factory
+from tests.testing import (
+    strict_lenient_test_helper_factory,
+    validation_test_helper_factory,
+)
 
 
-def test_code_fantoire():
-    _test_fantoir = strict_lenient_test_helper_factory(CodeFantoir)
+def test_code_fantoir():
+    _test_fantoir = validation_test_helper_factory(CodeFantoir)
 
-    fantoir_strict = ["ZB03"]
-    fantoir_lenient = ["zb04"]
-    fantoir_invalid = ["AAA"]
+    fantoir_valid = ["ZB03A"]
+    fantoir_invalid = ["1000"]
 
-    _test_fantoir(fantoir_strict, fantoir_lenient, fantoir_invalid)
+    _test_fantoir(fantoir_valid, True)
+    _test_fantoir(fantoir_invalid, False)
 
 
 def test_code_commune_insee():

--- a/src/tests/testing.py
+++ b/src/tests/testing.py
@@ -2,14 +2,22 @@ from typing import List
 
 
 def validation_test_helper_factory(Class):
-    def test_helper(test_cases: List[str], isStrict: bool, expectValid: bool) -> None:
-        adjective = "strictly" if isStrict else "leniently"
+    def test_helper(test_cases: List[str], expectValid: bool, **kwargs) -> None:
+        isStrict = kwargs["strict"] if "strict" in kwargs else None
+
+        if isStrict:
+            adjective = "strictly"
+        elif isStrict is False:
+            adjective = "leniently"
+        else:
+            adjective = ""
+
         validKeywoard = "valid" if expectValid else "invalid"
 
         for tc in test_cases:
             assert (
-                Class.is_valid(tc, strict=isStrict) == expectValid
-            ), f"Check that departement { tc } is { adjective } { validKeywoard }"
+                Class.is_valid(tc, **kwargs) == expectValid
+            ), f"Check that { Class.__name__ } { tc } is { adjective } { validKeywoard }"
 
     return test_helper
 
@@ -25,12 +33,12 @@ def strict_lenient_test_helper_factory(Class):
         lenient_test_cases: List[str],
         invalid_test_cases: List[str],
     ) -> None:
-        _test_class(strict_test_cases, isStrict=True, expectValid=True)
-        _test_class(lenient_test_cases, isStrict=True, expectValid=False)
-        _test_class(invalid_test_cases, isStrict=True, expectValid=False)
+        _test_class(strict_test_cases, expectValid=True, strict=True)
+        _test_class(lenient_test_cases, expectValid=False, strict=True)
+        _test_class(invalid_test_cases, expectValid=False, strict=True)
 
-        _test_class(strict_test_cases, isStrict=False, expectValid=True)
-        _test_class(lenient_test_cases, isStrict=False, expectValid=True)
-        _test_class(invalid_test_cases, isStrict=False, expectValid=False)
+        _test_class(strict_test_cases, expectValid=True, strict=False)
+        _test_class(lenient_test_cases, expectValid=True, strict=False)
+        _test_class(invalid_test_cases, expectValid=False, strict=False)
 
     return test_helper


### PR DESCRIPTION
La validation du code fantoir était erronnée (le dernier caractère était absent des codes validés). 

Voilà qui est réparé. 

J'en ai profité pour faire quelques petites corrections sur les helpers de test : 

- les rendre moins dépendant à la signature du check testé (strict devient facultatif) 
- corriger le helper pour indiquer le vrai nom de la classe testé ("département" était hardcodé dans le message d'erreur)

/!\ À noter que j'ai dévié de la regex utilisée dans csv detective : deux lettres semblent être possible en début de code fantoir. Format exact à vérifier plus proprement...