### PR TITLE
Refactor: Set a default value to options parameter

### DIFF
--- a/src/frformat/__init__.py
+++ b/src/frformat/__init__.py
@@ -19,7 +19,7 @@ from .geo.numero_departement import NumeroDepartement as NumeroDepartement
 from .geo.pays import Pays as Pays
 from .geo.region import Region as Region
 from .nomenclature_acte_format import NomenclatureActe as NomenclatureActe
-from .options import Options
+from .options import Options as Options
 from .siren import Siren as Siren
 from .siret import Siret as Siret
 

--- a/src/frformat/custom_format.py
+++ b/src/frformat/custom_format.py
@@ -18,6 +18,9 @@ class CustomFormat(ABC, Generic[ValueType]):
     metadata: Metadata
     formatter: Formatter = DefaultFormatter[ValueType]()
 
+    def __init__(self):
+        ...
+
     @abstractmethod
     def is_valid(self, value: ValueType) -> bool:
         ...

--- a/src/frformat/custom_format.py
+++ b/src/frformat/custom_format.py
@@ -18,9 +18,6 @@ class CustomFormat(ABC, Generic[ValueType]):
     metadata: Metadata
     formatter: Formatter = DefaultFormatter[ValueType]()
 
-    def __init__(self):
-        ...
-
     @abstractmethod
     def is_valid(self, value: ValueType) -> bool:
         ...

--- a/src/frformat/enum_format.py
+++ b/src/frformat/enum_format.py
@@ -11,8 +11,8 @@ def new(class_name: str, name: str, description: str, enum: Set[str]) -> Type:
 
         May preprocess the input and valid values according to given "options"."""
 
-        def __init__(self, options: Optional[Options] = None):
-            self.options = options if options is not None else Options()
+        def __init__(self, options: Options = Options()):
+            self.options = options
 
             _normalized_extra_values = {
                 normalize_value(e, self.options)

--- a/src/frformat/enum_format.py
+++ b/src/frformat/enum_format.py
@@ -1,4 +1,4 @@
-from typing import Optional, Set, Type
+from typing import Set, Type
 
 from frformat import CustomStrFormat, Metadata
 from frformat.common import normalize_value

--- a/src/frformat/enum_format.py
+++ b/src/frformat/enum_format.py
@@ -12,21 +12,21 @@ def new(class_name: str, name: str, description: str, enum: Set[str]) -> Type:
         May preprocess the input and valid values according to given "options"."""
 
         def __init__(self, options: Options = Options()):
-            self.options = options
+            self._options = options
 
             _normalized_extra_values = {
-                normalize_value(e, self.options)
-                for e in self.options.extra_valid_values
+                normalize_value(e, self._options)
+                for e in self._options.extra_valid_values
             }
 
             self._normalized_enum = {
-                normalize_value(e, self.options) for e in enum
+                normalize_value(e, self._options) for e in enum
             }.union(_normalized_extra_values)
 
         metadata = Metadata(name, description)
 
         def is_valid(self, value: str) -> bool:
-            normalized_value = normalize_value(value, self.options)
+            normalized_value = normalize_value(value, self._options)
             return normalized_value in self._normalized_enum
 
     EnumFormat.__name__ = class_name

--- a/src/frformat/enum_format.py
+++ b/src/frformat/enum_format.py
@@ -1,4 +1,4 @@
-from typing import Set, Type
+from typing import Optional, Set, Type
 
 from frformat import CustomStrFormat, Metadata
 from frformat.common import normalize_value
@@ -11,20 +11,22 @@ def new(class_name: str, name: str, description: str, enum: Set[str]) -> Type:
 
         May preprocess the input and valid values according to given "options"."""
 
-        def __init__(self, options: Options):
-            self._options = options
+        def __init__(self, options: Optional[Options] = None):
+            self.options = options if options is not None else Options()
+
             _normalized_extra_values = {
-                normalize_value(e, self._options)
-                for e in self._options.extra_valid_values
+                normalize_value(e, self.options)
+                for e in self.options.extra_valid_values
             }
+
             self._normalized_enum = {
-                normalize_value(e, self._options) for e in enum
+                normalize_value(e, self.options) for e in enum
             }.union(_normalized_extra_values)
 
         metadata = Metadata(name, description)
 
         def is_valid(self, value: str) -> bool:
-            normalized_value = normalize_value(value, self._options)
+            normalized_value = normalize_value(value, self.options)
             return normalized_value in self._normalized_enum
 
     EnumFormat.__name__ = class_name

--- a/src/tests/test_geo_fr.py
+++ b/src/tests/test_geo_fr.py
@@ -15,7 +15,6 @@ from frformat import (
     Region,
 )
 from frformat.common import NBSP, NNBSP
-from frformat.options import Options
 from tests.testing import strict_lenient_test_helper_factory
 
 
@@ -29,7 +28,7 @@ def test_code_fantoir():
 
 def test_code_commune_insee():
     value = "01015"
-    code_commune_insee = CodeCommuneInsee(Options())
+    code_commune_insee = CodeCommuneInsee()
     assert code_commune_insee.is_valid(value)
     assert code_commune_insee.format(value) == value
 
@@ -39,7 +38,7 @@ def test_code_commune_insee():
 
 def test_code_postal():
     value = "05560"
-    code_postal = CodePostal(Options())
+    code_postal = CodePostal()
     assert code_postal.is_valid(value)
     assert code_postal.format(value) == value
 


### PR DESCRIPTION
* The aim of this PR is to avoid using the options parameter when instantiating the class. For example, change from `"_code_postal = CodePostal(Options())"` to `"_code_postal = CodePostal()"`. 
In this case, options has a default value (all options are false) .