### PR TITLE
Feat: Add a new alternative to select the latest published version of the Official Geographic Code

### DIFF
--- a/src/frformat/geo/canton.py
+++ b/src/frformat/geo/canton.py
@@ -7,7 +7,7 @@ from frformat.geo_enum_format import Millesime
 name = "Nom de canton"
 description = "Vérifie que le nom de canton est un canton ou pseudo-canton français valide pour un Code Officiel Géographique donné"
 all_cog_versions: Dict[Millesime, FrozenSet[str]] = {
-    Millesime.A2023: CANTON_COG_2023,
-    Millesime.A2024: CANTON_COG_2024,
+    Millesime.M2023: CANTON_COG_2023,
+    Millesime.M2024: CANTON_COG_2024,
 }
 Canton = geo_enum_format.new("Canton", name, description, all_cog_versions)

--- a/src/frformat/geo/code_commune_insee.py
+++ b/src/frformat/geo/code_commune_insee.py
@@ -11,8 +11,8 @@ name = "Code commune INSEE"
 description = "Vérifie que le code commune correspond bien à un code commune INSEE pour un Code Officiel Géographique donné"
 
 all_cog_versions: Dict[Millesime, FrozenSet[str]] = {
-    Millesime.A2023: CODES_COMMUNES_INSEE_COG_2023,
-    Millesime.A2024: CODES_COMMUNES_INSEE_COG_2024,
+    Millesime.M2023: CODES_COMMUNES_INSEE_COG_2023,
+    Millesime.M2024: CODES_COMMUNES_INSEE_COG_2024,
 }
 CodeCommuneInsee = geo_enum_format.new(
     "CodeCommuneInsee", name, description, all_cog_versions

--- a/src/frformat/geo/code_pays.py
+++ b/src/frformat/geo/code_pays.py
@@ -13,8 +13,8 @@ name = "Codes ISO2 Pays"
 description = "Code ISO 2 de pays pour un Code Officiel Géographique donné"
 
 all_cog_versions: Dict[Millesime, FrozenSet[str]] = {
-    Millesime.A2023: CODES_PAYS_ISO2_COG_2023,
-    Millesime.A2024: CODES_PAYS_ISO2_COG_2024,
+    Millesime.M2023: CODES_PAYS_ISO2_COG_2023,
+    Millesime.M2024: CODES_PAYS_ISO2_COG_2024,
 }
 
 CodePaysISO2 = geo_enum_format.new("CodePaysISO2", name, description, all_cog_versions)
@@ -23,8 +23,8 @@ name = "Codes ISO3 Pays"
 description = "Code ISO 3 de pays pour un Code Officiel Géographique donné"
 
 all_cog_versions: Dict[Millesime, FrozenSet[str]] = {
-    Millesime.A2023: CODES_PAYS_ISO3_COG_2023,
-    Millesime.A2024: CODES_PAYS_ISO3_COG_2024,
+    Millesime.M2023: CODES_PAYS_ISO3_COG_2023,
+    Millesime.M2024: CODES_PAYS_ISO3_COG_2024,
 }
 
 CodePaysISO3 = geo_enum_format.new("CodePaysISO3", name, description, all_cog_versions)

--- a/src/frformat/geo/code_region.py
+++ b/src/frformat/geo/code_region.py
@@ -31,7 +31,7 @@ CODES_REGIONS_COG_2024 = CODES_REGIONS_COG_2023
 name = "Code région"
 description = "Vérifie qu'il s'agit d'un code région selon le Code Officiel Géographique (cog) donné"
 all_cog_versions: Dict[Millesime, FrozenSet[str]] = {
-    Millesime.A2023: CODES_REGIONS_COG_2023,
-    Millesime.A2024: CODES_REGIONS_COG_2024,
+    Millesime.M2023: CODES_REGIONS_COG_2023,
+    Millesime.M2024: CODES_REGIONS_COG_2024,
 }
 CodeRegion = geo_enum_format.new("CodeRegion", name, description, all_cog_versions)

--- a/src/frformat/geo/commune.py
+++ b/src/frformat/geo/commune.py
@@ -11,7 +11,7 @@ description = (
 )
 
 all_cog_versions: Dict[Millesime, FrozenSet[str]] = {
-    Millesime.A2023: COMMUNES_COG_2023,
-    Millesime.A2024: COMMUNES_COG_2024,
+    Millesime.M2023: COMMUNES_COG_2023,
+    Millesime.M2024: COMMUNES_COG_2024,
 }
 Commune = geo_enum_format.new("Commune", name, description, all_cog_versions)

--- a/src/frformat/geo/departement.py
+++ b/src/frformat/geo/departement.py
@@ -11,7 +11,7 @@ name = "Nom de département"
 description = "Vérifie les départements français, collectivités et territoires d'outre-mer valides pour un Code Officiel Géographique donné"
 
 all_cog_versions: Dict[Millesime, FrozenSet[str]] = {
-    Millesime.A2023: DEPARTEMENTS_COG_2023,
-    Millesime.A2024: DEPARTEMENTS_COG_2024,
+    Millesime.M2023: DEPARTEMENTS_COG_2023,
+    Millesime.M2024: DEPARTEMENTS_COG_2024,
 }
 Departement = geo_enum_format.new("Departement", name, description, all_cog_versions)

--- a/src/frformat/geo/numero_departement.py
+++ b/src/frformat/geo/numero_departement.py
@@ -17,8 +17,8 @@ name = "Numéro du département"
 description = "Vérifie que le numéro de département correspond bien à un numéro de département français, collectivités et territoires d'outre-mer pour un Code Officiel Géographique donné"
 
 all_cog_versions: Dict[Millesime, FrozenSet[str]] = {
-    Millesime.A2023: NUMEROS_DEPARTEMENTS_COG_2023,
-    Millesime.A2024: NUMEROS_DEPARTEMENTS_COG_2024,
+    Millesime.M2023: NUMEROS_DEPARTEMENTS_COG_2023,
+    Millesime.M2024: NUMEROS_DEPARTEMENTS_COG_2024,
 }
 NumeroDepartement = geo_enum_format.new(
     "NumeroDepartement", name, description, all_cog_versions

--- a/src/frformat/geo/pays.py
+++ b/src/frformat/geo/pays.py
@@ -10,7 +10,7 @@ description = (
 )
 
 all_cog_versions: Dict[Millesime, FrozenSet[str]] = {
-    Millesime.A2024: PAYS_COG_2024,
+    Millesime.M2024: PAYS_COG_2024,
 }
 
 Pays = geo_enum_format.new("Pays", name, description, all_cog_versions)

--- a/src/frformat/geo/region.py
+++ b/src/frformat/geo/region.py
@@ -10,7 +10,7 @@ description = (
 )
 
 all_cog_versions: Dict[Millesime, FrozenSet[str]] = {
-    Millesime.A2023: REGIONS_COG_2023,
-    Millesime.A2024: REGIONS_COG_2024,
+    Millesime.M2023: REGIONS_COG_2023,
+    Millesime.M2024: REGIONS_COG_2024,
 }
 Region = geo_enum_format.new("Region", name, description, all_cog_versions)

--- a/src/frformat/geo_enum_format.py
+++ b/src/frformat/geo_enum_format.py
@@ -10,6 +10,8 @@ class Millesime(Enum):
     A2023 = auto()
     A2024 = auto()
 
+    LATEST = A2024
+
 
 def new(
     class_name: str,

--- a/src/frformat/geo_enum_format.py
+++ b/src/frformat/geo_enum_format.py
@@ -7,10 +7,10 @@ from frformat.options import Options
 
 
 class Millesime(Enum):
-    A2023 = auto()
-    A2024 = auto()
+    M2023 = auto()
+    M2024 = auto()
 
-    LATEST = A2024
+    LATEST = M2024
 
 
 def new(

--- a/src/tests/test_geo_fr_with_cog.py
+++ b/src/tests/test_geo_fr_with_cog.py
@@ -14,8 +14,8 @@ from frformat import (
 
 
 def test_code_region():
-    code_region_2023 = CodeRegion(Millesime.A2023)
-    code_region_2024 = CodeRegion(Millesime.A2024)
+    code_region_2023 = CodeRegion(Millesime.M2023)
+    code_region_2024 = CodeRegion(Millesime.M2024)
     last_code_region = CodeRegion(Millesime.LATEST)
 
     valid_test_cases = ["01", "75"]
@@ -32,8 +32,8 @@ def test_code_region():
 
 
 def test_region():
-    region_2023 = Region(Millesime.A2023)
-    region_2024 = Region(Millesime.A2024)
+    region_2023 = Region(Millesime.M2023)
+    region_2024 = Region(Millesime.M2024)
     last_region = Region(Millesime.LATEST)
 
     valid_test_cases = ["Centre-Val de Loire", "La Réunion", "Corse"]
@@ -56,8 +56,8 @@ def test_region():
 
 
 def test_commune():
-    commune_2023 = Commune(Millesime.A2023)
-    commune_2024 = Commune(Millesime.A2024)
+    commune_2023 = Commune(Millesime.M2023)
+    commune_2024 = Commune(Millesime.M2024)
     last_commune = Commune(Millesime.LATEST)
 
     valid_test_cases_cog_2023 = [
@@ -115,8 +115,8 @@ def test_commune():
 
 
 def test_canton():
-    canton_2023 = Canton(Millesime.A2023)
-    canton_2024 = Canton(Millesime.A2024)
+    canton_2023 = Canton(Millesime.M2023)
+    canton_2024 = Canton(Millesime.M2024)
     last_canton = Canton(Millesime.LATEST)
 
     valid_test_cases_cog_2023 = [
@@ -151,12 +151,12 @@ def test_canton():
 
 
 def test_code_pays():
-    code_pays_2023_IS02 = CodePaysISO2(Millesime.A2023)
-    code_pays_2024_IS02 = CodePaysISO2(Millesime.A2024)
+    code_pays_2023_IS02 = CodePaysISO2(Millesime.M2023)
+    code_pays_2024_IS02 = CodePaysISO2(Millesime.M2024)
     last_code_pays_IS02 = CodePaysISO2(Millesime.LATEST)
 
-    code_pays_2023_IS03 = CodePaysISO3(Millesime.A2023)
-    code_pays_2024_IS03 = CodePaysISO3(Millesime.A2024)
+    code_pays_2023_IS03 = CodePaysISO3(Millesime.M2023)
+    code_pays_2024_IS03 = CodePaysISO3(Millesime.M2024)
     last_code_pays_IS03 = CodePaysISO3(Millesime.LATEST)
 
     valid_test_cases_iso2_cog_2023 = ["BV", "SJ"]
@@ -215,8 +215,8 @@ def test_code_pays():
 
 
 def test_code_commune_insee():
-    code_commune_insee_cog_2023 = CodeCommuneInsee(Millesime.A2023)
-    code_commune_insee_cog_2024 = CodeCommuneInsee(Millesime.A2024)
+    code_commune_insee_cog_2023 = CodeCommuneInsee(Millesime.M2023)
+    code_commune_insee_cog_2024 = CodeCommuneInsee(Millesime.M2024)
     last_code_commune_insee = CodeCommuneInsee(Millesime.LATEST)
 
     cog_2023_value = "01015"
@@ -249,8 +249,8 @@ def test_code_commune_insee():
 
 
 def test_departement():
-    departement_cog_2023 = Departement(Millesime.A2023)
-    departement_cog_2024 = Departement(Millesime.A2024)
+    departement_cog_2023 = Departement(Millesime.M2023)
+    departement_cog_2024 = Departement(Millesime.M2024)
     last_departement_cog = Departement(Millesime.LATEST)
 
     valid_test_cases = ["Alpes-Maritimes", "Gard", "Mayotte", "Vendée"]
@@ -268,7 +268,7 @@ def test_departement():
 
 
 def test_pays():
-    pays_cog_2024 = Pays(Millesime.A2024)
+    pays_cog_2024 = Pays(Millesime.M2024)
     last_pays_cog = Pays(Millesime.LATEST)
 
     valid_pays_cog_2024 = ["France", "Pays-Bas", "Bosnie-Herzégovine"]
@@ -291,8 +291,8 @@ def test_pays():
 
 
 def test_numero_departement():
-    num_departement_cog_2023 = NumeroDepartement(Millesime.A2023)
-    num_departement_cog_2024 = NumeroDepartement(Millesime.A2024)
+    num_departement_cog_2023 = NumeroDepartement(Millesime.M2023)
+    num_departement_cog_2024 = NumeroDepartement(Millesime.M2024)
     last_num_departement_cog = NumeroDepartement(Millesime.LATEST)
 
     num_departement_valid = ["05", "2B", "974"]

--- a/src/tests/test_geo_fr_with_cog.py
+++ b/src/tests/test_geo_fr_with_cog.py
@@ -16,25 +16,21 @@ from frformat import (
 def test_code_region():
     code_region_2023 = CodeRegion(Millesime.M2023)
     code_region_2024 = CodeRegion(Millesime.M2024)
-    last_code_region = CodeRegion(Millesime.LATEST)
 
     valid_test_cases = ["01", "75"]
     invalid_test_cases = ["AA", "00", "7 5"]
     for tc in valid_test_cases:
         assert code_region_2023.is_valid(tc)
         assert code_region_2024.is_valid(tc)
-        assert last_code_region.is_valid(tc)
 
     for tc in invalid_test_cases:
         assert not code_region_2023.is_valid(tc)
         assert not code_region_2024.is_valid(tc)
-        assert not last_code_region.is_valid(tc)
 
 
 def test_region():
     region_2023 = Region(Millesime.M2023)
     region_2024 = Region(Millesime.M2024)
-    last_region = Region(Millesime.LATEST)
 
     valid_test_cases = ["Centre-Val de Loire", "La Réunion", "Corse"]
     invalid_test_cases = [
@@ -47,18 +43,15 @@ def test_region():
     for tc in valid_test_cases:
         assert region_2023.is_valid(tc)
         assert region_2024.is_valid(tc)
-        assert last_region.is_valid(tc)
 
     for tc in invalid_test_cases:
         assert not region_2023.is_valid(tc)
         assert not region_2024.is_valid(tc)
-        assert not last_region.is_valid(tc)
 
 
 def test_commune():
     commune_2023 = Commune(Millesime.M2023)
     commune_2024 = Commune(Millesime.M2024)
-    last_commune = Commune(Millesime.LATEST)
 
     valid_test_cases_cog_2023 = [
         "La Chapelle-Achard",
@@ -82,8 +75,6 @@ def test_commune():
         "La Chapelle-Fleurigné",
     ]
 
-    valid_test_cases_last_cog = valid_test_cases_cog_2024
-
     invalid_test_cases_cog_2024 = [
         "Costa del Sol",
         "Montestrucq",
@@ -92,8 +83,6 @@ def test_commune():
         "montestrucq",
         "La Chapelle     Achard",
     ]
-
-    invalid_test_cases_last_cog = invalid_test_cases_cog_2024
 
     for tc in valid_test_cases_cog_2023:
         assert commune_2023.is_valid(tc)
@@ -107,17 +96,10 @@ def test_commune():
     for tc in invalid_test_cases_cog_2024:
         assert not commune_2024.is_valid(tc)
 
-    for tc in valid_test_cases_last_cog:
-        assert last_commune.is_valid(tc)
-
-    for tc in invalid_test_cases_last_cog:
-        assert not last_commune.is_valid(tc)
-
 
 def test_canton():
     canton_2023 = Canton(Millesime.M2023)
     canton_2024 = Canton(Millesime.M2024)
-    last_canton = Canton(Millesime.LATEST)
 
     valid_test_cases_cog_2023 = [
         "Lagnieu",
@@ -126,10 +108,8 @@ def test_canton():
     invalid_test_cases_cog_2023 = ["Paris", "Lyon", "paris"]
 
     valid_test_cases_cog_2024 = ["Paris", "Lyon"]
-    valid_test_cases_last_cog = valid_test_cases_cog_2024
 
     invalid_test_cases_cog_2024 = ["Saint Quentin", "saint  quentin"]
-    invalid_test_cases_last_cog = invalid_test_cases_cog_2024
 
     for tc in valid_test_cases_cog_2023:
         assert canton_2023.is_valid(tc)
@@ -143,21 +123,13 @@ def test_canton():
     for tc in invalid_test_cases_cog_2024:
         assert not canton_2024.is_valid(tc)
 
-    for tc in valid_test_cases_last_cog:
-        assert last_canton.is_valid(tc)
-
-    for tc in invalid_test_cases_last_cog:
-        assert not last_canton.is_valid(tc)
-
 
 def test_code_pays():
     code_pays_2023_IS02 = CodePaysISO2(Millesime.M2023)
     code_pays_2024_IS02 = CodePaysISO2(Millesime.M2024)
-    last_code_pays_IS02 = CodePaysISO2(Millesime.LATEST)
 
     code_pays_2023_IS03 = CodePaysISO3(Millesime.M2023)
     code_pays_2024_IS03 = CodePaysISO3(Millesime.M2024)
-    last_code_pays_IS03 = CodePaysISO3(Millesime.LATEST)
 
     valid_test_cases_iso2_cog_2023 = ["BV", "SJ"]
     invalid_test_cases_iso2_cog_2023 = ["RWA", "TCD", "rwa"]
@@ -165,17 +137,11 @@ def test_code_pays():
     valid_test_cases_iso2_cog_2024 = ["FR", "JP"]
     invalid_test_cases_iso2_cog_2024 = ["BV", "SJ", "bv"]
 
-    valid_test_cases_iso2_last_cog = valid_test_cases_iso2_cog_2024
-    invalid_test_cases_iso2_last_cog = invalid_test_cases_iso2_cog_2024
-
     valid_test_cases_iso3_cog_2023 = ["BVT", "SJM"]
     invalid_test_cases_iso3_cog_2023 = ["BF", "GH", "gh"]
 
     valid_test_cases_iso3_cog_2024 = ["FRA", "JPN"]
     invalid_test_cases_iso3_cog_2024 = ["BVT", "SJM", "bvt"]
-
-    valid_test_cases_iso3_last_cog = valid_test_cases_iso3_cog_2024
-    invalid_test_cases_iso3_last_cog = invalid_test_cases_iso3_cog_2024
 
     for tc in valid_test_cases_iso2_cog_2023:
         assert code_pays_2023_IS02.is_valid(tc)
@@ -189,12 +155,6 @@ def test_code_pays():
     for tc in invalid_test_cases_iso2_cog_2024:
         assert not code_pays_2024_IS02.is_valid(tc)
 
-    for tc in valid_test_cases_iso2_last_cog:
-        assert last_code_pays_IS02.is_valid(tc)
-
-    for tc in invalid_test_cases_iso2_last_cog:
-        assert not last_code_pays_IS02.is_valid(tc)
-
     for tc in valid_test_cases_iso3_cog_2023:
         assert code_pays_2023_IS03.is_valid(tc)
 
@@ -207,17 +167,10 @@ def test_code_pays():
     for tc in invalid_test_cases_iso3_cog_2024:
         assert not code_pays_2024_IS03.is_valid(tc)
 
-    for tc in valid_test_cases_iso3_last_cog:
-        assert last_code_pays_IS03.is_valid(tc)
-
-    for tc in invalid_test_cases_iso3_last_cog:
-        assert not last_code_pays_IS03.is_valid(tc)
-
 
 def test_code_commune_insee():
     code_commune_insee_cog_2023 = CodeCommuneInsee(Millesime.M2023)
     code_commune_insee_cog_2024 = CodeCommuneInsee(Millesime.M2024)
-    last_code_commune_insee = CodeCommuneInsee(Millesime.LATEST)
 
     cog_2023_value = "01015"
     assert code_commune_insee_cog_2023.is_valid(cog_2023_value)
@@ -229,29 +182,20 @@ def test_code_commune_insee():
         assert not code_commune_insee_cog_2023.is_valid(iv)
 
     cog_2024_value = "64300"
-    last_cog_value = cog_2024_value
 
     assert code_commune_insee_cog_2024.is_valid(cog_2024_value)
     assert code_commune_insee_cog_2024.format(cog_2024_value) == cog_2024_value
     assert code_commune_insee_cog_2024.is_valid("2A331")
 
-    assert last_code_commune_insee.is_valid(last_cog_value)
-    assert last_code_commune_insee.format(last_cog_value) == last_cog_value
-
     cog_2024_invalid_values = ["64402", "64  300"]
-    invalid_last_cog_values = cog_2024_invalid_values
 
     for iv in cog_2024_invalid_values:
         assert not code_commune_insee_cog_2024.is_valid(iv)
-
-    for iv in invalid_last_cog_values:
-        assert not last_code_commune_insee.is_valid(iv)
 
 
 def test_departement():
     departement_cog_2023 = Departement(Millesime.M2023)
     departement_cog_2024 = Departement(Millesime.M2024)
-    last_departement_cog = Departement(Millesime.LATEST)
 
     valid_test_cases = ["Alpes-Maritimes", "Gard", "Mayotte", "Vendée"]
     invalid_test_cases = ["Charente-Inférieure", "Vendee", "Alpes  maritimes"]
@@ -259,23 +203,17 @@ def test_departement():
     for tc in valid_test_cases:
         assert departement_cog_2023.is_valid(tc)
         assert departement_cog_2024.is_valid(tc)
-        assert last_departement_cog.is_valid(tc)
 
     for tc in invalid_test_cases:
         assert not departement_cog_2023.is_valid(tc)
         assert not departement_cog_2024.is_valid(tc)
-        assert not last_departement_cog.is_valid(tc)
 
 
 def test_pays():
     pays_cog_2024 = Pays(Millesime.M2024)
-    last_pays_cog = Pays(Millesime.LATEST)
 
     valid_pays_cog_2024 = ["France", "Pays-Bas", "Bosnie-Herzégovine"]
     invalid_pays_cog_2024 = ["L'Eldorado", "Zubrowska", "Pays Bas", "france"]
-
-    valid_last_pays_cog = valid_pays_cog_2024
-    invalid_last_pays_cog = invalid_pays_cog_2024
 
     for tc in valid_pays_cog_2024:
         assert pays_cog_2024.is_valid(tc)
@@ -283,17 +221,10 @@ def test_pays():
     for tc in invalid_pays_cog_2024:
         assert not pays_cog_2024.is_valid(tc)
 
-    for tc in valid_last_pays_cog:
-        assert last_pays_cog.is_valid(tc)
-
-    for tc in invalid_last_pays_cog:
-        assert not last_pays_cog.is_valid(tc)
-
 
 def test_numero_departement():
     num_departement_cog_2023 = NumeroDepartement(Millesime.M2023)
     num_departement_cog_2024 = NumeroDepartement(Millesime.M2024)
-    last_num_departement_cog = NumeroDepartement(Millesime.LATEST)
 
     num_departement_valid = ["05", "2B", "974"]
     num_departement_invalid = ["99", "051", "2b", "  97 4"]
@@ -301,9 +232,7 @@ def test_numero_departement():
     for tc in num_departement_valid:
         assert num_departement_cog_2023.is_valid(tc)
         assert num_departement_cog_2024.is_valid(tc)
-        assert last_num_departement_cog.is_valid(tc)
 
     for tc in num_departement_invalid:
         assert not num_departement_cog_2023.is_valid(tc)
         assert not num_departement_cog_2024.is_valid(tc)
-        assert not last_num_departement_cog.is_valid(tc)

--- a/src/tests/test_geo_fr_with_cog.py
+++ b/src/tests/test_geo_fr_with_cog.py
@@ -16,21 +16,25 @@ from frformat import (
 def test_code_region():
     code_region_2023 = CodeRegion(Millesime.A2023)
     code_region_2024 = CodeRegion(Millesime.A2024)
+    last_code_region = CodeRegion(Millesime.LATEST)
 
     valid_test_cases = ["01", "75"]
     invalid_test_cases = ["AA", "00", "7 5"]
     for tc in valid_test_cases:
         assert code_region_2023.is_valid(tc)
         assert code_region_2024.is_valid(tc)
+        assert last_code_region.is_valid(tc)
 
     for tc in invalid_test_cases:
         assert not code_region_2023.is_valid(tc)
         assert not code_region_2024.is_valid(tc)
+        assert not last_code_region.is_valid(tc)
 
 
 def test_region():
     region_2023 = Region(Millesime.A2023)
     region_2024 = Region(Millesime.A2024)
+    last_region = Region(Millesime.LATEST)
 
     valid_test_cases = ["Centre-Val de Loire", "La Réunion", "Corse"]
     invalid_test_cases = [
@@ -43,15 +47,18 @@ def test_region():
     for tc in valid_test_cases:
         assert region_2023.is_valid(tc)
         assert region_2024.is_valid(tc)
+        assert last_region.is_valid(tc)
 
     for tc in invalid_test_cases:
         assert not region_2023.is_valid(tc)
         assert not region_2024.is_valid(tc)
+        assert not last_region.is_valid(tc)
 
 
 def test_commune():
     commune_2023 = Commune(Millesime.A2023)
     commune_2024 = Commune(Millesime.A2024)
+    last_commune = Commune(Millesime.LATEST)
 
     valid_test_cases_cog_2023 = [
         "La Chapelle-Achard",
@@ -74,6 +81,9 @@ def test_commune():
         "Val-d'Usiers",
         "La Chapelle-Fleurigné",
     ]
+
+    valid_test_cases_last_cog = valid_test_cases_cog_2024
+
     invalid_test_cases_cog_2024 = [
         "Costa del Sol",
         "Montestrucq",
@@ -82,6 +92,8 @@ def test_commune():
         "montestrucq",
         "La Chapelle     Achard",
     ]
+
+    invalid_test_cases_last_cog = invalid_test_cases_cog_2024
 
     for tc in valid_test_cases_cog_2023:
         assert commune_2023.is_valid(tc)
@@ -95,10 +107,17 @@ def test_commune():
     for tc in invalid_test_cases_cog_2024:
         assert not commune_2024.is_valid(tc)
 
+    for tc in valid_test_cases_last_cog:
+        assert last_commune.is_valid(tc)
+
+    for tc in invalid_test_cases_last_cog:
+        assert not last_commune.is_valid(tc)
+
 
 def test_canton():
     canton_2023 = Canton(Millesime.A2023)
     canton_2024 = Canton(Millesime.A2024)
+    last_canton = Canton(Millesime.LATEST)
 
     valid_test_cases_cog_2023 = [
         "Lagnieu",
@@ -107,7 +126,10 @@ def test_canton():
     invalid_test_cases_cog_2023 = ["Paris", "Lyon", "paris"]
 
     valid_test_cases_cog_2024 = ["Paris", "Lyon"]
+    valid_test_cases_last_cog = valid_test_cases_cog_2024
+
     invalid_test_cases_cog_2024 = ["Saint Quentin", "saint  quentin"]
+    invalid_test_cases_last_cog = invalid_test_cases_cog_2024
 
     for tc in valid_test_cases_cog_2023:
         assert canton_2023.is_valid(tc)
@@ -121,12 +143,21 @@ def test_canton():
     for tc in invalid_test_cases_cog_2024:
         assert not canton_2024.is_valid(tc)
 
+    for tc in valid_test_cases_last_cog:
+        assert last_canton.is_valid(tc)
+
+    for tc in invalid_test_cases_last_cog:
+        assert not last_canton.is_valid(tc)
+
 
 def test_code_pays():
     code_pays_2023_IS02 = CodePaysISO2(Millesime.A2023)
     code_pays_2024_IS02 = CodePaysISO2(Millesime.A2024)
+    last_code_pays_IS02 = CodePaysISO2(Millesime.LATEST)
+
     code_pays_2023_IS03 = CodePaysISO3(Millesime.A2023)
     code_pays_2024_IS03 = CodePaysISO3(Millesime.A2024)
+    last_code_pays_IS03 = CodePaysISO3(Millesime.LATEST)
 
     valid_test_cases_iso2_cog_2023 = ["BV", "SJ"]
     invalid_test_cases_iso2_cog_2023 = ["RWA", "TCD", "rwa"]
@@ -134,11 +165,17 @@ def test_code_pays():
     valid_test_cases_iso2_cog_2024 = ["FR", "JP"]
     invalid_test_cases_iso2_cog_2024 = ["BV", "SJ", "bv"]
 
+    valid_test_cases_iso2_last_cog = valid_test_cases_iso2_cog_2024
+    invalid_test_cases_iso2_last_cog = invalid_test_cases_iso2_cog_2024
+
     valid_test_cases_iso3_cog_2023 = ["BVT", "SJM"]
     invalid_test_cases_iso3_cog_2023 = ["BF", "GH", "gh"]
 
     valid_test_cases_iso3_cog_2024 = ["FRA", "JPN"]
     invalid_test_cases_iso3_cog_2024 = ["BVT", "SJM", "bvt"]
+
+    valid_test_cases_iso3_last_cog = valid_test_cases_iso3_cog_2024
+    invalid_test_cases_iso3_last_cog = invalid_test_cases_iso3_cog_2024
 
     for tc in valid_test_cases_iso2_cog_2023:
         assert code_pays_2023_IS02.is_valid(tc)
@@ -152,6 +189,12 @@ def test_code_pays():
     for tc in invalid_test_cases_iso2_cog_2024:
         assert not code_pays_2024_IS02.is_valid(tc)
 
+    for tc in valid_test_cases_iso2_last_cog:
+        assert last_code_pays_IS02.is_valid(tc)
+
+    for tc in invalid_test_cases_iso2_last_cog:
+        assert not last_code_pays_IS02.is_valid(tc)
+
     for tc in valid_test_cases_iso3_cog_2023:
         assert code_pays_2023_IS03.is_valid(tc)
 
@@ -164,10 +207,17 @@ def test_code_pays():
     for tc in invalid_test_cases_iso3_cog_2024:
         assert not code_pays_2024_IS03.is_valid(tc)
 
+    for tc in valid_test_cases_iso3_last_cog:
+        assert last_code_pays_IS03.is_valid(tc)
+
+    for tc in invalid_test_cases_iso3_last_cog:
+        assert not last_code_pays_IS03.is_valid(tc)
+
 
 def test_code_commune_insee():
     code_commune_insee_cog_2023 = CodeCommuneInsee(Millesime.A2023)
     code_commune_insee_cog_2024 = CodeCommuneInsee(Millesime.A2024)
+    last_code_commune_insee = CodeCommuneInsee(Millesime.LATEST)
 
     cog_2023_value = "01015"
     assert code_commune_insee_cog_2023.is_valid(cog_2023_value)
@@ -179,18 +229,29 @@ def test_code_commune_insee():
         assert not code_commune_insee_cog_2023.is_valid(iv)
 
     cog_2024_value = "64300"
+    last_cog_value = cog_2024_value
+
     assert code_commune_insee_cog_2024.is_valid(cog_2024_value)
     assert code_commune_insee_cog_2024.format(cog_2024_value) == cog_2024_value
     assert code_commune_insee_cog_2024.is_valid("2A331")
 
+    assert last_code_commune_insee.is_valid(last_cog_value)
+    assert last_code_commune_insee.format(last_cog_value) == last_cog_value
+
     cog_2024_invalid_values = ["64402", "64  300"]
+    invalid_last_cog_values = cog_2024_invalid_values
+
     for iv in cog_2024_invalid_values:
         assert not code_commune_insee_cog_2024.is_valid(iv)
+
+    for iv in invalid_last_cog_values:
+        assert not last_code_commune_insee.is_valid(iv)
 
 
 def test_departement():
     departement_cog_2023 = Departement(Millesime.A2023)
     departement_cog_2024 = Departement(Millesime.A2024)
+    last_departement_cog = Departement(Millesime.LATEST)
 
     valid_test_cases = ["Alpes-Maritimes", "Gard", "Mayotte", "Vendée"]
     invalid_test_cases = ["Charente-Inférieure", "Vendee", "Alpes  maritimes"]
@@ -198,17 +259,23 @@ def test_departement():
     for tc in valid_test_cases:
         assert departement_cog_2023.is_valid(tc)
         assert departement_cog_2024.is_valid(tc)
+        assert last_departement_cog.is_valid(tc)
 
     for tc in invalid_test_cases:
         assert not departement_cog_2023.is_valid(tc)
         assert not departement_cog_2024.is_valid(tc)
+        assert not last_departement_cog.is_valid(tc)
 
 
 def test_pays():
     pays_cog_2024 = Pays(Millesime.A2024)
+    last_pays_cog = Pays(Millesime.LATEST)
 
     valid_pays_cog_2024 = ["France", "Pays-Bas", "Bosnie-Herzégovine"]
     invalid_pays_cog_2024 = ["L'Eldorado", "Zubrowska", "Pays Bas", "france"]
+
+    valid_last_pays_cog = valid_pays_cog_2024
+    invalid_last_pays_cog = invalid_pays_cog_2024
 
     for tc in valid_pays_cog_2024:
         assert pays_cog_2024.is_valid(tc)
@@ -216,10 +283,17 @@ def test_pays():
     for tc in invalid_pays_cog_2024:
         assert not pays_cog_2024.is_valid(tc)
 
+    for tc in valid_last_pays_cog:
+        assert last_pays_cog.is_valid(tc)
+
+    for tc in invalid_last_pays_cog:
+        assert not last_pays_cog.is_valid(tc)
+
 
 def test_numero_departement():
     num_departement_cog_2023 = NumeroDepartement(Millesime.A2023)
     num_departement_cog_2024 = NumeroDepartement(Millesime.A2024)
+    last_num_departement_cog = NumeroDepartement(Millesime.LATEST)
 
     num_departement_valid = ["05", "2B", "974"]
     num_departement_invalid = ["99", "051", "2b", "  97 4"]
@@ -227,7 +301,9 @@ def test_numero_departement():
     for tc in num_departement_valid:
         assert num_departement_cog_2023.is_valid(tc)
         assert num_departement_cog_2024.is_valid(tc)
+        assert last_num_departement_cog.is_valid(tc)
 
     for tc in num_departement_invalid:
         assert not num_departement_cog_2023.is_valid(tc)
         assert not num_departement_cog_2024.is_valid(tc)
+        assert not last_num_departement_cog.is_valid(tc)


### PR DESCRIPTION
# Goal
* The aim of this PR is to allow users of the `fr-format` package to select the latest Official Geographic Code published by INSEE, manually defined in the code.
