### PR TITLE
Feat/code postal data

### DIFF
--- a/docs/formats.md
+++ b/docs/formats.md
@@ -7,7 +7,7 @@
 | CodeFantoir | Code fantoir | Vérifie les codes fantoirs valides |
 | CodePaysISO2 | Codes ISO2 Pays | Code ISO 2 de pays pour un Code Officiel Géographique donné |
 | CodePaysISO3 | Codes ISO3 Pays | Code ISO 3 de pays pour un Code Officiel Géographique donné |
-| CodePostal | Code postal | Vérifie que le code postal est bien un code postal français |
+| CodePostal | Code postal | Vérifie que le code postal est bien un code postal français. La dernière mise à jour date du 8 février 2025 |
 | CodeRegion | Code région | Vérifie qu'il s'agit d'un code région selon le Code Officiel Géographique (cog) donné |
 | Commune | Nom de commune | Vérifie que le nom correspond à un nom de commune française pour un Code Officiel Géographique donné(ne vérifie pas l'accentuation, la casse, la ponctuation) |
 | CoordonneesGPSFrancaises | Coordonnées GPS françaises | Check that GPS coordinates are in a bounding box approximating France (including DOM) |

--- a/src/frformat/__init__.py
+++ b/src/frformat/__init__.py
@@ -22,7 +22,7 @@ from .formats.region import Region as Region
 from .formats.siren import Siren as Siren
 from .formats.siret import Siret as Siret
 from .options import Options as Options
-from .set_format import Millesime as Millesime
+from .versions import Millesime as Millesime
 
 all_formats = [
     Canton,

--- a/src/frformat/formats/canton.py
+++ b/src/frformat/formats/canton.py
@@ -1,7 +1,8 @@
 from frformat import set_format
 from frformat.formats.canton_frozenset import CANTON_COG_2023, CANTON_COG_2024
-from frformat.set_format import INSEE_SOURCE, Millesime
+from frformat.set_format import INSEE_SOURCE
 from frformat.versioned_set import VersionedSet
+from frformat.versions import Millesime
 
 name = "Nom de canton"
 description = "Vérifie que le nom de canton est un canton ou pseudo-canton français valide pour un Code Officiel Géographique donné"

--- a/src/frformat/formats/code_commune_insee.py
+++ b/src/frformat/formats/code_commune_insee.py
@@ -3,8 +3,9 @@ from frformat.formats.code_commune_insee_frozenset import (
     CODES_COMMUNES_INSEE_COG_2023,
     CODES_COMMUNES_INSEE_COG_2024,
 )
-from frformat.set_format import INSEE_SOURCE, Millesime
+from frformat.set_format import INSEE_SOURCE
 from frformat.versioned_set import VersionedSet
+from frformat.versions import Millesime
 
 name = "Code commune INSEE"
 description = "Vérifie que le code commune correspond bien à un code commune INSEE pour un Code Officiel Géographique donné"

--- a/src/frformat/formats/code_pays.py
+++ b/src/frformat/formats/code_pays.py
@@ -5,8 +5,9 @@ from frformat.formats.code_pays_frozenset import (
     CODES_PAYS_ISO3_COG_2023,
     CODES_PAYS_ISO3_COG_2024,
 )
-from frformat.set_format import INSEE_SOURCE, Millesime
+from frformat.set_format import INSEE_SOURCE
 from frformat.versioned_set import VersionedSet
+from frformat.versions import Millesime
 
 name = "Codes ISO2 Pays"
 description = "Code ISO 2 de pays pour un Code Officiel Géographique donné"

--- a/src/frformat/formats/code_postal.py
+++ b/src/frformat/formats/code_postal.py
@@ -2,7 +2,7 @@ from frformat import set_format
 from frformat.formats.code_postal_frozenset import CODES_POSTAUX
 
 name = "Code postal"
-description = "Vérifie que le code postal est bien un code postal français"
-source = ""
+description = "Vérifie que le code postal est bien un code postal français. La dernière mise à jour date du 8 février 2025"
+source = "https://datanova.laposte.fr/datasets/laposte-hexasmal"
 
 CodePostal = set_format.new("CodePostal", name, description, source, CODES_POSTAUX)

--- a/src/frformat/formats/code_region.py
+++ b/src/frformat/formats/code_region.py
@@ -1,6 +1,7 @@
 from frformat import set_format
-from frformat.set_format import INSEE_SOURCE, Millesime
+from frformat.set_format import INSEE_SOURCE
 from frformat.versioned_set import VersionedSet
+from frformat.versions import Millesime
 
 CODES_REGIONS_COG_2023 = frozenset(
     {

--- a/src/frformat/formats/commune.py
+++ b/src/frformat/formats/commune.py
@@ -1,7 +1,8 @@
 from frformat import set_format
 from frformat.formats.commune_frozenset import COMMUNES_COG_2023, COMMUNES_COG_2024
-from frformat.set_format import INSEE_SOURCE, Millesime
+from frformat.set_format import INSEE_SOURCE
 from frformat.versioned_set import VersionedSet
+from frformat.versions import Millesime
 
 name = "Nom de commune"
 description = (

--- a/src/frformat/formats/departement.py
+++ b/src/frformat/formats/departement.py
@@ -3,8 +3,9 @@ from frformat.formats.departement_frozenset import (
     DEPARTEMENTS_COG_2023,
     DEPARTEMENTS_COG_2024,
 )
-from frformat.set_format import INSEE_SOURCE, Millesime
+from frformat.set_format import INSEE_SOURCE
 from frformat.versioned_set import VersionedSet
+from frformat.versions import Millesime
 
 name = "Nom de département"
 description = "Vérifie les départements français, collectivités et territoires d'outre-mer valides pour un Code Officiel Géographique donné"

--- a/src/frformat/formats/numero_departement.py
+++ b/src/frformat/formats/numero_departement.py
@@ -1,6 +1,7 @@
 from frformat import set_format
-from frformat.set_format import INSEE_SOURCE, Millesime
+from frformat.set_format import INSEE_SOURCE
 from frformat.versioned_set import VersionedSet
+from frformat.versions import Millesime
 
 NUMEROS_DEPARTEMENTS_COG_2023 = frozenset(
     (

--- a/src/frformat/formats/pays.py
+++ b/src/frformat/formats/pays.py
@@ -1,7 +1,8 @@
 from frformat import set_format
 from frformat.formats.pays_frozenset import PAYS_COG_2024
-from frformat.set_format import INSEE_SOURCE, Millesime
+from frformat.set_format import INSEE_SOURCE
 from frformat.versioned_set import VersionedSet
+from frformat.versions import Millesime
 
 name = "Pays et territoires étrangers"
 description = (

--- a/src/frformat/formats/region.py
+++ b/src/frformat/formats/region.py
@@ -1,7 +1,8 @@
 from frformat import set_format
 from frformat.formats.region_frozenset import REGIONS_COG_2023, REGIONS_COG_2024
-from frformat.set_format import INSEE_SOURCE, Millesime
+from frformat.set_format import INSEE_SOURCE
 from frformat.versioned_set import VersionedSet
+from frformat.versions import Millesime
 
 name = "Nom de région"
 description = (

--- a/src/frformat/set_format.py
+++ b/src/frformat/set_format.py
@@ -8,36 +8,12 @@ This module introduces utilities to efficiently create new set formats :
 - `new` creates specialized versions where data is tied to the class
 """
 
-from enum import Enum
-from functools import total_ordering
 from typing import FrozenSet, Generic, Type, TypeVar, Union, overload
 
 from frformat import CustomStrFormat, Metadata
 from frformat.common import normalize_value
 from frformat.options import Options
 from frformat.versioned_set import Version, VersionedSet
-
-
-@total_ordering
-class Millesime(Enum):
-    """Millesime class implements the `Version` protocol methods."""
-
-    M2023 = "2023"
-    M2024 = "2024"
-    LATEST = "latest"
-
-    def __eq__(self, other) -> bool:
-        return self.value == other.value
-
-    def __lt__(self, other) -> bool:
-        return self.value < other.value
-
-    def get_id(self) -> str:
-        return self.value
-
-    @classmethod
-    def is_sorted(cls) -> bool:
-        return True
 
 
 class SingleSetFormat(CustomStrFormat):

--- a/src/frformat/versions.py
+++ b/src/frformat/versions.py
@@ -1,0 +1,24 @@
+from enum import Enum
+from functools import total_ordering
+
+
+@total_ordering
+class Millesime(Enum):
+    """Millesime class implements the `Version` protocol methods."""
+
+    M2023 = "2023"
+    M2024 = "2024"
+    LATEST = "latest"
+
+    def __eq__(self, other) -> bool:
+        return self.value == other.value
+
+    def __lt__(self, other) -> bool:
+        return self.value < other.value
+
+    def get_id(self) -> str:
+        return self.value
+
+    @classmethod
+    def is_sorted(cls) -> bool:
+        return True

--- a/src/tests/test_set_format.py
+++ b/src/tests/test_set_format.py
@@ -1,8 +1,9 @@
 import pytest
 
 from frformat import set_format
-from frformat.set_format import Millesime, new
+from frformat.set_format import new
 from frformat.versioned_set import VersionedSet
+from frformat.versions import Millesime
 
 
 def test_format_validation():


### PR DESCRIPTION
# Context

After extensive research, I found a reliable reference source on [dataNova](https://datanova.laposte.fr/), the open data portal of La Poste Groupe.  

I retrieved the latest data for the `CodePostal` format updated on 8 February 2025.

However, no history of data has been found on this source.

# Goal

The purpose of this PR is to update the `CodePostal` format with new versioned data that is more robust and backed by a trusted source.